### PR TITLE
Move from diccolecte.org to grammalecte.net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build: deps flycheck-grammalecte.elc
 deps: grammalecte/__init__.py
 
 grammalecte/__init__.py:
-	wget https://www.dicollecte.org/grammalecte/zip/Grammalecte-fr-v$(GRAMVER).zip
+	wget https://grammalecte.net/grammalecte/zip/Grammalecte-fr-v$(GRAMVER).zip
 	mkdir Grammalecte-fr-v$(GRAMVER)
 	unzip Grammalecte-fr-v$(GRAMVER).zip -d Grammalecte-fr-v$(GRAMVER)
 	mv Grammalecte-fr-v$(GRAMVER)/grammalecte .

--- a/flycheck-grammalecte.el
+++ b/flycheck-grammalecte.el
@@ -105,7 +105,7 @@ The default value is automatically computed from the included file.")
                   flycheck-grammalecte-grammalecte-version
                   ".zip"))
          (fgm-dl-url
-          (concat "https://www.dicollecte.org/grammalecte/zip/"
+          (concat "https://grammalecte.net/grammalecte/zip/"
                   fgm-zip-name))
          (fgm-zip-file (expand-file-name
                         fgm-zip-name


### PR DESCRIPTION
Two small modifications to fix the down diccolecte domain and thus the error on zip retrieval.

Tested on my home emacs with success.